### PR TITLE
Removal of misplaced quotations around Route snippets

### DIFF
--- a/snippets/dependson.cson
+++ b/snippets/dependson.cson
@@ -1,0 +1,4 @@
+'.source.json':
+  'dependson':
+    'prefix': 'dependson'
+    'body': '"DependsOn": "${1:-}"'

--- a/snippets/getazs.cson
+++ b/snippets/getazs.cson
@@ -1,0 +1,4 @@
+'.source.json':
+  'getazs':
+    'prefix': 'getazs'
+    'body': '{ "Fn::GetAZs" : "${1:regionName}" }'

--- a/snippets/route-table-assoc.cson
+++ b/snippets/route-table-assoc.cson
@@ -1,4 +1,4 @@
 '.source.json':
   'route-table-assoc':
     'prefix': 'route-table-assoc'
-    'body': '"${1:routeTableAssocName"}: {\n  "Type": "AWS::EC2::SubnetRouteTableAssociation",\n  "Properties": {\n    "SubnetId": ${2:"--"},\n    "RouteTableId": ${3:"--"}\n  }\n}'
+    'body': '"${1:routeTableAssocName}": {\n  "Type": "AWS::EC2::SubnetRouteTableAssociation",\n  "Properties": {\n    "SubnetId": ${2:"--"},\n    "RouteTableId": ${3:"--"}\n  }\n}'

--- a/snippets/route.cson
+++ b/snippets/route.cson
@@ -1,4 +1,4 @@
 '.source.json':
   'route':
     'prefix': 'route'
-    'body': '"${1:routeName}": {\n  "Type": "AWS::EC2::Route",\n  "Properties": {\n    "RouteTableId": ${2:"--"},\n    "DestinationCidrBlock": "${3:"--"},\n    "GatewayId": ${4:"--"}\n  }\n}'
+    'body': '"${1:routeName}": {\n  "Type": "AWS::EC2::Route",\n  "Properties": {\n    "RouteTableId": ${2:"--"},\n    "DestinationCidrBlock": ${3:"--"},\n    "GatewayId": ${4:"--"}\n  }\n}'


### PR DESCRIPTION
Found one quote that was being held within selected text after snippet execution for the route name in route.cson and an 'extra' quotation on the route-table-association snippet.
