### PR TITLE
Adding CodeBuild

### DIFF
--- a/snippets/codebuild.cson
+++ b/snippets/codebuild.cson
@@ -1,0 +1,4 @@
+'.source.json':
+  'codebuild':
+    'prefix': 'codebuild'
+    'body': '"${1:codeBuild}": {\n  "Type": "AWS::CodeBuild::Project",\n  "Properties" : {\n    "Artifacts" : "${2}",\n    "Environment" : "${3}",\n    "Name" : "${4}",\n    "ServiceRole" : "${5}",\n    "Source" : "${6}",\n  }\n}'


### PR DESCRIPTION
Adding the [CloudFormation CodeBuild](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codebuild-project.html) resource. This PR only includes the required parameters for CodeBuild, so optional ones like `Tags` and `EncryptionKey` fields are not included.